### PR TITLE
Restart redis immediately to free up the port.

### DIFF
--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -32,6 +32,6 @@ template "/etc/redis/redis.conf" do
   owner "root"
   group "root"
   mode 0644
-  notifies :restart, resources(:service => "redis-server")
+  notifies :restart, resources(:service => "redis-server"), :immediately
 end
 


### PR DESCRIPTION
By default, chef notifications are run delayed, which means they are
run after all resources were executed.  This makes the haproxy setup
for redis fail because haproxy will also listen on the same port as
redis.  This change will make redis restart immediately so it frees up
the port for use by haproxy.
